### PR TITLE
LEX namespace restructuring: extension category defaults

### DIFF
--- a/lib/legion/settings/loader.rb
+++ b/lib/legion/settings/loader.rb
@@ -38,7 +38,25 @@ module Legion
             vault:                  { connected: false }
           },
           cache:                      { enabled: true, connected: false, driver: 'dalli' },
-          extensions:                 {},
+          extensions:                 {
+            core:              %w[
+              lex-node lex-tasker lex-scheduler lex-health lex-ping
+              lex-telemetry lex-metering lex-log lex-audit
+              lex-conditioner lex-transformer lex-exec lex-lex lex-codegen
+            ],
+            ai:                %w[lex-claude lex-openai lex-gemini],
+            gaia:              %w[lex-tick lex-mesh lex-apollo lex-cortex],
+            categories:        {
+              core:    { type: :list, tier: 1 },
+              ai:      { type: :list, tier: 2 },
+              gaia:    { type: :list, tier: 3 },
+              agentic: { type: :prefix, tier: 4 }
+            },
+            blocked:           [],
+            reserved_prefixes: %w[core ai agentic gaia],
+            reserved_words:    %w[transport cache crypt data settings json logging llm rbac legion],
+            agentic:           { allowed: nil, blocked: [] }
+          },
           reload:                     false,
           reloading:                  false,
           auto_install_missing_lex:   true,

--- a/spec/legion/loader_spec.rb
+++ b/spec/legion/loader_spec.rb
@@ -59,8 +59,8 @@ RSpec.describe Legion::Settings::Loader do
       expect(defaults[:cache][:driver]).to eq('dalli')
     end
 
-    it 'has empty extensions' do
-      expect(defaults[:extensions]).to eq({})
+    it 'has extensions hash' do
+      expect(defaults[:extensions]).to be_a(Hash)
     end
 
     it 'has logging settings' do
@@ -252,6 +252,34 @@ RSpec.describe Legion::Settings::Loader do
       loader.set_env!
       contents = File.read(ENV.fetch('LEGION_LOADED_TEMPFILE', nil))
       expect(contents).to include(config_file)
+    end
+  end
+
+  describe '#default_settings extension categories' do
+    subject(:defaults) { loader.default_settings }
+
+    it 'includes extension category lists' do
+      expect(defaults[:extensions][:core]).to be_an(Array)
+      expect(defaults[:extensions][:ai]).to be_an(Array)
+      expect(defaults[:extensions][:gaia]).to be_an(Array)
+      expect(defaults[:extensions][:core]).to include('lex-node', 'lex-tasker')
+      expect(defaults[:extensions][:ai]).to include('lex-claude', 'lex-openai', 'lex-gemini')
+      expect(defaults[:extensions][:gaia]).to include('lex-tick', 'lex-apollo')
+    end
+
+    it 'includes category registry' do
+      cats = defaults[:extensions][:categories]
+      expect(cats[:core]).to eq({ type: :list, tier: 1 })
+      expect(cats[:ai]).to eq({ type: :list, tier: 2 })
+      expect(cats[:gaia]).to eq({ type: :list, tier: 3 })
+      expect(cats[:agentic]).to eq({ type: :prefix, tier: 4 })
+    end
+
+    it 'includes governance defaults' do
+      expect(defaults[:extensions][:blocked]).to eq([])
+      expect(defaults[:extensions][:agentic]).to eq({ allowed: nil, blocked: [] })
+      expect(defaults[:extensions][:reserved_prefixes]).to include('agentic', 'core', 'ai', 'gaia')
+      expect(defaults[:extensions][:reserved_words]).to include('transport', 'cache', 'data')
     end
   end
 


### PR DESCRIPTION
## Summary

Adds extension category configuration defaults to `Legion::Settings` to support the LEX namespace restructuring in LegionIO.

## Changes

- Adds `:core`, `:ai`, `:gaia` gem lists to `extensions` defaults (defined-list categories)
- Adds `:categories` registry with type (`:list`/`:prefix`) and tier ordering
- Adds governance defaults: `:blocked` list, `:reserved_prefixes`, `:reserved_words`
- Adds `:agentic` sub-filtering config (`{ allowed: nil, blocked: [] }`)

## Category Tiers

| Tier | Category | Type | Gems |
|------|----------|------|------|
| 1 | core | list | lex-node, lex-tasker, lex-scheduler, ... (14 gems) |
| 2 | ai | list | lex-claude, lex-openai, lex-gemini |
| 3 | gaia | list | lex-tick, lex-mesh, lex-apollo, lex-cortex |
| 4 | agentic | prefix | any `lex-agentic-*` gem |
| 5 | default | — | everything else |

## Related PRs

- LegionIO: LEX namespace restructuring (depends on this)