### PR TITLE
include filename in config json parse errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Legion::Settings Changelog
 
+## [1.3.3] - 2026-03-17
+
+### Fixed
+- Config JSON parse error now includes the filename at ERROR level instead of burying it in DEBUG
+
 ## [1.3.2] - 2026-03-17
 
 ### Added

--- a/docs/plans/2026-03-17-config-error-filename-design.md
+++ b/docs/plans/2026-03-17-config-error-filename-design.md
@@ -1,0 +1,56 @@
+# Design: Include Filename in JSON Parse Error Messages
+
+## Problem
+
+When a user edits a config file and introduces a JSON syntax error, the settings loader logs:
+
+```
+ERROR config file must be valid json
+```
+
+The filename is only logged at DEBUG level on the next line:
+
+```ruby
+Legion::Logging.error('config file must be valid json')
+Legion::Logging.debug("file:#{file}, error: #{e}")
+```
+
+This makes it nearly impossible for users to identify which file is broken, especially when multiple config files exist in `~/.legionio/settings/`. The settings loader silently skips the broken file, and downstream code fails with confusing errors (e.g., RubyLLM complaining about missing API keys because `llm.json` wasn't loaded).
+
+## Proposed Solution
+
+Change `load_file` in `loader.rb` to include the filename and parse error in the ERROR message:
+
+```ruby
+rescue Legion::JSON::ParseError => e
+  Legion::Logging.error("config file must be valid json: #{file}")
+  Legion::Logging.error("  parse error: #{e.message}")
+end
+```
+
+This is a one-line change (plus one added line) in `loader.rb:140-142`.
+
+### Before
+
+```
+[2026-03-17 18:27:27 -0500] ERROR config file must be valid json
+```
+
+### After
+
+```
+[2026-03-17 18:27:27 -0500] ERROR config file must be valid json: /Users/matt/.legionio/settings/llm.json
+[2026-03-17 18:27:27 -0500] ERROR   parse error: unexpected token at '{ "llm": { ... '
+```
+
+## Alternatives Considered
+
+1. **Raise instead of logging** — rejected; the current behavior of skipping broken files and continuing is correct for resilience. But the user needs to know what happened.
+2. **Add a `config validate` pre-check** — already exists (`legion config validate`), but users won't run it proactively. The error message at load time is the first line of defense.
+3. **Return the broken files in `loaded_files`** — would require API changes for minimal benefit.
+
+## Constraints
+
+- Do not change the error-handling behavior (continue loading other files)
+- Do not change method signatures
+- The debug line can be removed since the info is now in the error message

--- a/docs/plans/2026-03-17-config-error-filename-implementation.md
+++ b/docs/plans/2026-03-17-config-error-filename-implementation.md
@@ -1,0 +1,34 @@
+# Implementation: Include Filename in JSON Parse Error Messages
+
+## Phase 1: Update Error Logging
+
+### Files to Modify
+
+- `lib/legion/settings/loader.rb` — lines 140-142
+
+### Changes
+
+Replace:
+
+```ruby
+rescue Legion::JSON::ParseError => e
+  Legion::Logging.error('config file must be valid json')
+  Legion::Logging.debug("file:#{file}, error: #{e}")
+```
+
+With:
+
+```ruby
+rescue Legion::JSON::ParseError => e
+  Legion::Logging.error("config file must be valid json: #{file}")
+  Legion::Logging.error("  parse error: #{e.message}")
+```
+
+### Spec Coverage
+
+- Add spec in `spec/legion/loader_spec.rb` that writes invalid JSON to a temp file, calls `load_file`, and asserts the error was logged with the filename
+
+### Version Bump
+
+- Bump patch version in `lib/legion/settings/version.rb`
+- Update CHANGELOG.md

--- a/lib/legion/settings/loader.rb
+++ b/lib/legion/settings/loader.rb
@@ -138,8 +138,8 @@ module Legion
             # @indifferent_access = false
             @loaded_files << file
           rescue Legion::JSON::ParseError => e
-            Legion::Logging.error('config file must be valid json')
-            Legion::Logging.debug("file:#{file}, error: #{e}")
+            Legion::Logging.error("config file must be valid json: #{file}")
+            Legion::Logging.error("  parse error: #{e.message}")
           end
         else
           Legion::Logging.warn("Config file does not exist or is not readable file:#{file}")

--- a/lib/legion/settings/version.rb
+++ b/lib/legion/settings/version.rb
@@ -2,6 +2,6 @@
 
 module Legion
   module Settings
-    VERSION = '1.3.2'
+    VERSION = '1.3.3'
   end
 end

--- a/spec/legion/loader_spec.rb
+++ b/spec/legion/loader_spec.rb
@@ -123,6 +123,13 @@ RSpec.describe Legion::Settings::Loader do
       expect(loader.loaded_files).not_to include(invalid_file)
     end
 
+    it 'logs the filename when JSON is invalid' do
+      invalid_file = File.join(assets_dir, 'invalid.json')
+      expect(Legion::Logging).to receive(:error).with(a_string_including(invalid_file))
+      expect(Legion::Logging).to receive(:error).with(a_string_matching(/parse error/))
+      loader.load_file(invalid_file)
+    end
+
     it 'handles a nonexistent file gracefully' do
       expect { loader.load_file('/tmp/nonexistent_legion_test_file.json') }.not_to raise_error
       expect(loader.loaded_files).to be_empty


### PR DESCRIPTION
## Summary
- Config JSON parse errors now include the filename at ERROR level instead of burying it in DEBUG
- Previously, a broken config file (e.g., `~/.legionio/settings/llm.json`) would log `config file must be valid json` with no indication of which file was broken
- Now logs: `config file must be valid json: /path/to/broken.json` + `parse error: <message>`

### Before
```
ERROR config file must be valid json
```

### After
```
ERROR config file must be valid json: /Users/matt/.legionio/settings/llm.json
ERROR   parse error: unexpected token at '{ "llm": { ... '
```

## Changes
- `lib/legion/settings/loader.rb` — include filename and parse error in ERROR log (2-line change)
- `lib/legion/settings/version.rb` — bump 1.3.2 → 1.3.3
- `spec/legion/loader_spec.rb` — new spec asserting filename appears in error log
- `CHANGELOG.md` — v1.3.3 entry
- Design + implementation docs in `docs/plans/`

## Test plan
- [x] 195 specs pass, 0 failures
- [x] 95.28% line coverage
- [x] 0 rubocop offenses