### PR TITLE
add per-request overlay and per-project .legionio.env config (#9, #10)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Legion::Settings Changelog
 
+## [1.3.25] - 2026-03-31
+
+### Added
+- `Settings.with_overlay(overrides) { }` — thread-local request-scoped settings overlay for per-tenant LLM routing without node restarts; nestable, cleans up via ensure block (closes #9)
+- `Settings.load_project_env(start_dir:)` — discovers and loads `.legionio.env` from Dir.pwd upward; dot-notation keys (`llm.default_model=haiku`) map to nested settings paths; auto-called during `Settings.load` (closes #10)
+- `Legion::Settings::Overlay` module — thread-local overlay storage with `with_overlay`, `current_overlay`, `overlay_for`, `clear_overlay!`
+- `Legion::Settings::ProjectEnv` module — env file discovery, parsing, and merging
+- Resolution order: request overlay > project `.legionio.env` > global settings
+- 44 new specs covering overlay scoping/nesting/cleanup, thread isolation, `.legionio.env` parsing, discovery, key mapping, and resolution order
+
 ## [1.3.24] - 2026-03-30
 
 ### Added

--- a/Gemfile
+++ b/Gemfile
@@ -10,5 +10,6 @@ group :test do
   gem 'rspec'
   gem 'rspec_junit_formatter'
   gem 'rubocop'
+  gem 'rubocop-legion'
   gem 'simplecov'
 end

--- a/lib/legion/settings.rb
+++ b/lib/legion/settings.rb
@@ -7,6 +7,8 @@ require 'legion/settings/loader'
 require 'legion/settings/schema'
 require 'legion/settings/validation_error'
 require 'legion/settings/helper'
+require 'legion/settings/overlay'
+require 'legion/settings/project_env'
 
 module Legion
   module Settings
@@ -35,6 +37,7 @@ module Legion
         end
 
         @loaded = true if has_config
+        load_project_env
         logger.info("Settings loaded from #{@loader.loaded_files.size} files")
         @loader
       end
@@ -50,7 +53,15 @@ module Legion
       def [](key)
         logger.info('Legion::Settings was not loading, auto loading now!') if @loader.nil?
         ensure_loader
-        @loader[key]
+        overlay_val = Overlay.overlay_for(key)
+        base_val = @loader[key]
+        if overlay_val.is_a?(Hash) && base_val.is_a?(Hash)
+          deep_merge_for_overlay(base_val, overlay_val)
+        elsif !overlay_val.nil?
+          overlay_val
+        else
+          base_val
+        end
       rescue NoMethodError, TypeError => e
         Legion::Logging.debug("Legion::Settings#[] key=#{key} failed: #{e.message}") if defined?(Legion::Logging)
         nil
@@ -84,6 +95,28 @@ module Legion
 
       def add_cross_validation(&block)
         cross_validations << block
+      end
+
+      # Execute a block with thread-local settings overrides active.
+      # Overlays are nestable — inner overlays merge on top of outer ones.
+      # Resolution order inside the block: overlay > project env > global settings.
+      #
+      # @param overrides [Hash] settings to override for the duration of the block
+      # @yield the block executed with the overlay active
+      # @return the return value of the block
+      def with_overlay(overrides, &)
+        Overlay.with_overlay(overrides, &)
+      end
+
+      # Load (or reload) the nearest `.legionio.env` file into the settings loader.
+      # Searches from Dir.pwd upward.  Env-file values take priority over global
+      # settings but are overridden by a request overlay (with_overlay).
+      #
+      # @param start_dir [String, nil] directory to start searching from (defaults to Dir.pwd)
+      # @return [String, nil] path to the loaded file, or nil if none found
+      def load_project_env(start_dir: nil)
+        ensure_loader
+        ProjectEnv.load_into(@loader.settings, start_dir: start_dir)
       end
 
       def dev_mode?
@@ -143,6 +176,7 @@ module Legion
         @loaded = nil
         @schema = nil
         @cross_validations = nil
+        Overlay.clear_overlay!
       end
 
       def logger
@@ -159,6 +193,19 @@ module Legion
       end
 
       private
+
+      def deep_merge_for_overlay(base, overlay)
+        result = base.dup
+        overlay.each do |key, value|
+          existing = result[key]
+          result[key] = if existing.is_a?(Hash) && value.is_a?(Hash)
+                          deep_merge_for_overlay(existing, value)
+                        else
+                          value
+                        end
+        end
+        result
+      end
 
       def ensure_loader
         return @loader if @loader

--- a/lib/legion/settings/overlay.rb
+++ b/lib/legion/settings/overlay.rb
@@ -1,0 +1,78 @@
+# frozen_string_literal: true
+
+module Legion
+  module Settings
+    # Thread-local request-scoped settings overlay.
+    #
+    # Provides block-scoped overrides that sit above global settings in the
+    # resolution order: request overlay > project .legionio.env > global settings.
+    #
+    # Usage:
+    #   Legion::Settings.with_overlay(llm: { default_model: 'claude-3-haiku' }) do
+    #     Legion::Settings[:llm][:default_model]  # => 'claude-3-haiku'
+    #   end
+    #
+    # Overlays are nestable — inner overlay merges on top of the outer one.
+    module Overlay
+      THREAD_KEY = :legion_settings_overlay
+
+      class << self
+        # Execute a block with the given overrides active in the current thread.
+        # The overrides hash uses the same top-level key structure as Settings.
+        #
+        # @param overrides [Hash] settings to override for the duration of the block
+        # @yield block executed with the overlay active
+        # @return the return value of the block
+        def with_overlay(overrides)
+          previous = Thread.current[THREAD_KEY]
+          Thread.current[THREAD_KEY] = deep_merge(previous || {}, overrides)
+          yield
+        ensure
+          Thread.current[THREAD_KEY] = previous
+        end
+
+        # Return the current thread-local overlay hash, or nil if none is active.
+        #
+        # @return [Hash, nil]
+        def current_overlay
+          Thread.current[THREAD_KEY]
+        end
+
+        # Clear the thread-local overlay for the current thread.
+        def clear_overlay!
+          Thread.current[THREAD_KEY] = nil
+        end
+
+        # Resolve a top-level key against the active overlay, returning the
+        # overlay value (which may need to be merged with base) or nil when no
+        # overlay is set.
+        #
+        # @param key [Symbol, String]
+        # @return [Object, nil]
+        def overlay_for(key)
+          overlay = Thread.current[THREAD_KEY]
+          return nil unless overlay
+
+          sym_key = key.to_sym
+          str_key = key.to_s
+          overlay[sym_key] || overlay[str_key]
+        end
+
+        private
+
+        def deep_merge(base, overrides)
+          result = base.dup
+          overrides.each do |key, value|
+            existing = result[key]
+            result[key] = if existing.is_a?(Hash) && value.is_a?(Hash)
+                            deep_merge(existing, value)
+                          else
+                            value
+                          end
+          end
+          result
+        end
+      end
+    end
+  end
+end

--- a/lib/legion/settings/project_env.rb
+++ b/lib/legion/settings/project_env.rb
@@ -1,0 +1,120 @@
+# frozen_string_literal: true
+
+module Legion
+  module Settings
+    # Per-project `.legionio.env` config file loader.
+    #
+    # Walks up from Dir.pwd searching for a `.legionio.env` file.  When found,
+    # parses `KEY=VALUE` lines with dot-notation keys and merges them into the
+    # loader at a priority between global settings and the request overlay.
+    #
+    # File format:
+    #   # comment lines are ignored
+    #   llm.default_model=claude-sonnet-4-5-20241022
+    #   cache.driver=redis
+    #
+    # Keys use dot notation to address nested settings paths.
+    # Values are always strings; callers should coerce as needed.
+    #
+    # Resolution order (lowest → highest priority):
+    #   global settings < .legionio.env < request overlay (#9)
+    module ProjectEnv
+      ENV_FILENAME = '.legionio.env'
+
+      class << self
+        # Walk up from +start_dir+ (defaults to Dir.pwd) looking for
+        # `.legionio.env`.  Returns the first file found, or nil.
+        #
+        # @param start_dir [String, nil] directory to start the search from
+        # @return [String, nil] absolute path to the file, or nil
+        def find_project_env_file(start_dir: nil)
+          dir = File.expand_path(start_dir || Dir.pwd)
+          loop do
+            candidate = File.join(dir, ENV_FILENAME)
+            return candidate if File.file?(candidate) && File.readable?(candidate)
+
+            parent = File.dirname(dir)
+            break if parent == dir # filesystem root
+
+            dir = parent
+          end
+          nil
+        end
+
+        # Parse a `.legionio.env` file and return a nested hash of overrides.
+        #
+        # @param path [String] absolute path to the file
+        # @return [Hash] nested hash with symbol keys
+        def parse_env_file(path)
+          result = {}
+          File.readlines(path, chomp: true).each_with_index do |line, idx|
+            next if line.strip.empty?
+            next if line.strip.start_with?('#')
+
+            parts = line.split('=', 2)
+            unless parts.length == 2
+              log_warn("#{path}:#{idx + 1}: skipping malformed line (no '=' found)")
+              next
+            end
+
+            raw_key, value = parts
+            key_parts = raw_key.strip.split('.')
+            if key_parts.empty? || key_parts.any?(&:empty?)
+              log_warn("#{path}:#{idx + 1}: skipping invalid key '#{raw_key.strip}'")
+              next
+            end
+
+            set_nested(result, key_parts.map(&:to_sym), value.strip)
+          end
+          result
+        end
+
+        # Find and load the project env file into the given settings hash,
+        # merging overrides (env file values win over existing values).
+        #
+        # @param settings [Hash] the settings hash to merge into (mutated in place)
+        # @param start_dir [String, nil] directory to start searching from
+        # @return [String, nil] path to the loaded file, or nil if none found
+        def load_into(settings, start_dir: nil)
+          path = find_project_env_file(start_dir: start_dir)
+          return nil unless path
+
+          overrides = parse_env_file(path)
+          deep_merge_into!(settings, overrides)
+          log_debug("ProjectEnv: loaded #{path}")
+          path
+        end
+
+        private
+
+        def set_nested(hash, keys, value)
+          *parents, leaf = keys
+          target = parents.reduce(hash) do |h, k|
+            h[k] ||= {}
+            h[k]
+          end
+          target[leaf] = value
+        end
+
+        def deep_merge_into!(base, overrides)
+          overrides.each do |key, value|
+            if base[key].is_a?(Hash) && value.is_a?(Hash)
+              deep_merge_into!(base[key], value)
+            else
+              base[key] = value
+            end
+          end
+          base
+        end
+
+        def log_debug(message)
+          defined?(Legion::Logging) ? Legion::Logging.debug(message) : nil
+        end
+
+        def log_warn(message)
+          defined?(Legion::Logging) ? Legion::Logging.warn(message) : warn(message)
+        end
+      end
+    end
+  end
+end

--- a/lib/legion/settings/version.rb
+++ b/lib/legion/settings/version.rb
@@ -2,6 +2,6 @@
 
 module Legion
   module Settings
-    VERSION = '1.3.24'
+    VERSION = '1.3.25'
   end
 end

--- a/spec/legion/settings/overlay_spec.rb
+++ b/spec/legion/settings/overlay_spec.rb
@@ -1,0 +1,171 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'legion/settings'
+require 'legion/settings/overlay'
+
+RSpec.describe Legion::Settings::Overlay do
+  before { described_class.clear_overlay! }
+  after  { described_class.clear_overlay! }
+
+  describe '.with_overlay' do
+    it 'yields the block' do
+      called = false
+      described_class.with_overlay(foo: 'bar') { called = true }
+      expect(called).to be true
+    end
+
+    it 'returns the block return value' do
+      result = described_class.with_overlay(x: 1) { 42 }
+      expect(result).to eq(42)
+    end
+
+    it 'makes the overlay visible inside the block' do
+      described_class.with_overlay(llm: { default_model: 'haiku' }) do
+        expect(described_class.current_overlay).to include(llm: { default_model: 'haiku' })
+      end
+    end
+
+    it 'cleans up the overlay after the block completes' do
+      described_class.with_overlay(foo: 'bar') { nil }
+      expect(described_class.current_overlay).to be_nil
+    end
+
+    it 'cleans up the overlay even when the block raises' do
+      expect do
+        described_class.with_overlay(foo: 'bar') { raise 'boom' }
+      end.to raise_error(RuntimeError, 'boom')
+      expect(described_class.current_overlay).to be_nil
+    end
+  end
+
+  describe '.current_overlay' do
+    it 'returns nil when no overlay is active' do
+      expect(described_class.current_overlay).to be_nil
+    end
+
+    it 'returns the active overlay inside a block' do
+      described_class.with_overlay(a: 1) do
+        expect(described_class.current_overlay).to eq(a: 1)
+      end
+    end
+  end
+
+  describe '.overlay_for' do
+    it 'returns nil when no overlay is active' do
+      expect(described_class.overlay_for(:llm)).to be_nil
+    end
+
+    it 'returns the overlay value for a top-level symbol key' do
+      described_class.with_overlay(llm: { default_model: 'opus' }) do
+        expect(described_class.overlay_for(:llm)).to eq(default_model: 'opus')
+      end
+    end
+
+    it 'accepts string keys' do
+      described_class.with_overlay('cache' => { driver: 'redis' }) do
+        expect(described_class.overlay_for('cache')).to eq(driver: 'redis')
+      end
+    end
+  end
+
+  describe 'nesting' do
+    it 'merges inner overlay on top of outer overlay' do
+      described_class.with_overlay(llm: { default_model: 'sonnet', temperature: 0.7 }) do
+        described_class.with_overlay(llm: { default_model: 'haiku' }) do
+          overlay = described_class.current_overlay
+          expect(overlay[:llm][:default_model]).to eq('haiku')
+          expect(overlay[:llm][:temperature]).to eq(0.7)
+        end
+      end
+    end
+
+    it 'restores the outer overlay after the inner block' do
+      described_class.with_overlay(llm: { default_model: 'sonnet' }) do
+        described_class.with_overlay(llm: { default_model: 'haiku' }) { nil }
+        expect(described_class.current_overlay[:llm][:default_model]).to eq('sonnet')
+      end
+    end
+
+    it 'adds new keys from the inner overlay without overwriting unrelated outer keys' do
+      described_class.with_overlay(cache: { driver: 'redis' }) do
+        described_class.with_overlay(llm: { default_model: 'opus' }) do
+          overlay = described_class.current_overlay
+          expect(overlay[:cache]).to eq(driver: 'redis')
+          expect(overlay[:llm]).to eq(default_model: 'opus')
+        end
+      end
+    end
+  end
+
+  describe 'thread isolation' do
+    it 'overlay in one thread does not affect another thread' do
+      other_overlay = nil
+      described_class.with_overlay(secret: 'x') do
+        t = Thread.new { other_overlay = described_class.current_overlay }
+        t.join
+      end
+      expect(other_overlay).to be_nil
+    end
+  end
+
+  describe '.clear_overlay!' do
+    it 'clears any active overlay for the current thread' do
+      described_class.with_overlay(foo: 'bar') do
+        described_class.clear_overlay!
+        expect(described_class.current_overlay).to be_nil
+      end
+    end
+  end
+end
+
+RSpec.describe Legion::Settings do
+  before { described_class.reset! }
+  after  { described_class.reset! }
+
+  describe '.with_overlay' do
+    it 'delegates to Overlay.with_overlay' do
+      result = nil
+      described_class.with_overlay(llm: { default_model: 'haiku' }) do
+        result = Legion::Settings::Overlay.current_overlay
+      end
+      expect(result).to include(llm: { default_model: 'haiku' })
+    end
+
+    it 'overrides [] for the duration of the block (scalar override)' do
+      described_class.with_overlay(custom_overlay_key: 'injected') do
+        expect(described_class[:custom_overlay_key]).to eq('injected')
+      end
+    end
+
+    it 'overrides [] for a nested hash key, merging with base settings' do
+      described_class.merge_settings('mymod', { host: 'localhost', port: 5672 })
+      described_class.with_overlay(mymod: { port: 9999 }) do
+        expect(described_class[:mymod][:port]).to eq(9999)
+        expect(described_class[:mymod][:host]).to eq('localhost')
+      end
+    end
+
+    it 'restores original value after the block' do
+      described_class.merge_settings('mymod2', { host: 'localhost' })
+      described_class.with_overlay(mymod2: { host: 'override' }) { nil }
+      expect(described_class[:mymod2][:host]).to eq('localhost')
+    end
+
+    it 'does not affect [] outside the block' do
+      expect(described_class[:cache][:driver]).to eq('dalli')
+      described_class.with_overlay(cache: { driver: 'redis' }) do
+        expect(described_class[:cache][:driver]).to eq('redis')
+      end
+      expect(described_class[:cache][:driver]).to eq('dalli')
+    end
+  end
+
+  describe 'resolution order: overlay > base' do
+    it 'overlay takes precedence over global settings' do
+      described_class.with_overlay(transport: { host: 'overlay-host' }) do
+        expect(described_class[:transport][:host]).to eq('overlay-host')
+      end
+    end
+  end
+end

--- a/spec/legion/settings/project_env_spec.rb
+++ b/spec/legion/settings/project_env_spec.rb
@@ -1,0 +1,213 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'tmpdir'
+require 'fileutils'
+require 'legion/settings'
+require 'legion/settings/project_env'
+
+RSpec.describe Legion::Settings::ProjectEnv do
+  let(:tmpdir) { Dir.mktmpdir('legion_project_env_test') }
+
+  after { FileUtils.rm_rf(tmpdir) }
+
+  # -----------------------------------------------------------------------
+  # find_project_env_file
+  # -----------------------------------------------------------------------
+  describe '.find_project_env_file' do
+    it 'returns nil when no .legionio.env file exists in the tree' do
+      empty_dir = File.join(tmpdir, 'empty')
+      FileUtils.mkdir_p(empty_dir)
+      expect(described_class.find_project_env_file(start_dir: empty_dir)).to be_nil
+    end
+
+    it 'finds .legionio.env in the start directory' do
+      env_file = File.join(tmpdir, '.legionio.env')
+      File.write(env_file, '')
+      expect(described_class.find_project_env_file(start_dir: tmpdir)).to eq(env_file)
+    end
+
+    it 'finds .legionio.env in a parent directory' do
+      child_dir = File.join(tmpdir, 'child', 'grandchild')
+      FileUtils.mkdir_p(child_dir)
+      env_file = File.join(tmpdir, '.legionio.env')
+      File.write(env_file, '')
+      expect(described_class.find_project_env_file(start_dir: child_dir)).to eq(env_file)
+    end
+
+    it 'prefers the nearest ancestor' do
+      child_dir = File.join(tmpdir, 'child')
+      FileUtils.mkdir_p(child_dir)
+      parent_file = File.join(tmpdir, '.legionio.env')
+      child_file  = File.join(child_dir, '.legionio.env')
+      File.write(parent_file, '')
+      File.write(child_file, '')
+      expect(described_class.find_project_env_file(start_dir: child_dir)).to eq(child_file)
+    end
+
+    it 'defaults start_dir to Dir.pwd when omitted' do
+      allow(Dir).to receive(:pwd).and_return(tmpdir)
+      env_file = File.join(tmpdir, '.legionio.env')
+      File.write(env_file, '')
+      expect(described_class.find_project_env_file).to eq(env_file)
+    end
+  end
+
+  # -----------------------------------------------------------------------
+  # parse_env_file
+  # -----------------------------------------------------------------------
+  describe '.parse_env_file' do
+    def write_env(content)
+      path = File.join(tmpdir, '.legionio.env')
+      File.write(path, content)
+      path
+    end
+
+    it 'parses a simple flat key' do
+      path = write_env("foo=bar\n")
+      expect(described_class.parse_env_file(path)).to eq(foo: 'bar')
+    end
+
+    it 'parses a dot-notation key into a nested hash' do
+      path = write_env("llm.default_model=claude-sonnet\n")
+      expect(described_class.parse_env_file(path)).to eq(llm: { default_model: 'claude-sonnet' })
+    end
+
+    it 'parses deeply nested dot-notation keys' do
+      path = write_env("transport.connection.host=rabbit.local\n")
+      expect(described_class.parse_env_file(path)).to eq(
+        transport: { connection: { host: 'rabbit.local' } }
+      )
+    end
+
+    it 'ignores comment lines' do
+      path = write_env("# this is a comment\nfoo=bar\n")
+      expect(described_class.parse_env_file(path)).to eq(foo: 'bar')
+    end
+
+    it 'ignores blank lines' do
+      path = write_env("\n\nfoo=bar\n\n")
+      expect(described_class.parse_env_file(path)).to eq(foo: 'bar')
+    end
+
+    it 'preserves equals signs in the value' do
+      path = write_env("auth.token=abc=def==ghi\n")
+      expect(described_class.parse_env_file(path)[:auth][:token]).to eq('abc=def==ghi')
+    end
+
+    it 'returns an empty hash for an empty file' do
+      path = write_env('')
+      expect(described_class.parse_env_file(path)).to eq({})
+    end
+
+    it 'strips leading/trailing whitespace from keys and values' do
+      path = write_env("  llm.model  =  sonnet  \n")
+      expect(described_class.parse_env_file(path)).to eq(llm: { model: 'sonnet' })
+    end
+
+    it 'skips malformed lines without raising' do
+      path = write_env("this_has_no_equals\nfoo=bar\n")
+      expect { described_class.parse_env_file(path) }.not_to raise_error
+      expect(described_class.parse_env_file(path)).to eq(foo: 'bar')
+    end
+
+    it 'parses multiple keys correctly' do
+      path = write_env("llm.model=haiku\ncache.driver=redis\n")
+      result = described_class.parse_env_file(path)
+      expect(result[:llm][:model]).to eq('haiku')
+      expect(result[:cache][:driver]).to eq('redis')
+    end
+  end
+
+  # -----------------------------------------------------------------------
+  # load_into
+  # -----------------------------------------------------------------------
+  describe '.load_into' do
+    it 'returns nil when no .legionio.env file is found' do
+      empty_dir = File.join(tmpdir, 'no_env')
+      FileUtils.mkdir_p(empty_dir)
+      settings = {}
+      expect(described_class.load_into(settings, start_dir: empty_dir)).to be_nil
+    end
+
+    it 'returns the path of the loaded file' do
+      env_file = File.join(tmpdir, '.legionio.env')
+      File.write(env_file, "foo=bar\n")
+      settings = {}
+      expect(described_class.load_into(settings, start_dir: tmpdir)).to eq(env_file)
+    end
+
+    it 'merges parsed values into the settings hash' do
+      env_file = File.join(tmpdir, '.legionio.env')
+      File.write(env_file, "llm.default_model=haiku\n")
+      settings = {}
+      described_class.load_into(settings, start_dir: tmpdir)
+      expect(settings[:llm][:default_model]).to eq('haiku')
+    end
+
+    it 'env file values override existing settings' do
+      env_file = File.join(tmpdir, '.legionio.env')
+      File.write(env_file, "cache.driver=redis\n")
+      settings = { cache: { driver: 'dalli', enabled: true } }
+      described_class.load_into(settings, start_dir: tmpdir)
+      expect(settings[:cache][:driver]).to eq('redis')
+      expect(settings[:cache][:enabled]).to eq(true)
+    end
+  end
+end
+
+# -----------------------------------------------------------------------
+# Integration: Legion::Settings.load_project_env
+# -----------------------------------------------------------------------
+RSpec.describe Legion::Settings do
+  let(:tmpdir) { Dir.mktmpdir('legion_settings_project_env_test') }
+
+  before { described_class.reset! }
+  after do
+    described_class.reset!
+    FileUtils.rm_rf(tmpdir)
+  end
+
+  describe '.load_project_env' do
+    it 'returns nil when no .legionio.env is found' do
+      empty = File.join(tmpdir, 'empty')
+      FileUtils.mkdir_p(empty)
+      expect(described_class.load_project_env(start_dir: empty)).to be_nil
+    end
+
+    it 'loads the .legionio.env file and makes values accessible via []' do
+      env_file = File.join(tmpdir, '.legionio.env')
+      File.write(env_file, "project_env_key=project_value\n")
+      described_class.load_project_env(start_dir: tmpdir)
+      expect(described_class[:project_env_key]).to eq('project_value')
+    end
+
+    it 'env file values override global settings' do
+      described_class.merge_settings('cache', { driver: 'dalli' })
+      env_file = File.join(tmpdir, '.legionio.env')
+      File.write(env_file, "cache.driver=redis\n")
+      described_class.load_project_env(start_dir: tmpdir)
+      expect(described_class[:cache][:driver]).to eq('redis')
+    end
+  end
+
+  describe 'resolution order: overlay > project env > global' do
+    it 'overlay beats project env beats global' do
+      described_class.merge_settings('mymod', { mode: 'global' })
+      env_file = File.join(tmpdir, '.legionio.env')
+      File.write(env_file, "mymod.mode=project\n")
+      described_class.load_project_env(start_dir: tmpdir)
+
+      # project env overrides global
+      expect(described_class[:mymod][:mode]).to eq('project')
+
+      # overlay overrides project env
+      described_class.with_overlay(mymod: { mode: 'overlay' }) do
+        expect(described_class[:mymod][:mode]).to eq('overlay')
+      end
+
+      # back to project env after overlay exits
+      expect(described_class[:mymod][:mode]).to eq('project')
+    end
+  end
+end


### PR DESCRIPTION
## Summary
- **#9**: Add `Settings.with_overlay(overrides) { }` for thread-local request-scoped settings overlay — enables per-tenant LLM routing without node restarts
- **#10**: Add `.legionio.env` file discovery and loading for per-project config overrides with dot-notation key mapping

Resolution order: request overlay > project .legionio.env > global settings

Closes #9, closes #10

## Test Coverage
- Specs for with_overlay block scoping, nesting, cleanup
- Specs for .legionio.env parsing, discovery, key mapping
- Specs for resolution order across all layers
- `bundle exec rspec` — all passing
- `bundle exec rubocop` — zero offenses