### PR TITLE
release legion-settings 1.3.26

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,11 +4,15 @@
 
 ### Changed
 - Added a runtime dependency on `legion-logging >= 1.4.0` and moved `Settings`, `Loader`, `Resolver`, `ProjectEnv`, and `AgentLoader` onto component-aware logging helpers
+- Added `Legion::Logging::Helper` integration to top-level `Settings` access and DNS bootstrap logging so component tags and per-component levels apply consistently
 - `extensions.default_extension_settings` now defaults to `{}` instead of injecting a synthetic logger config
 - `Legion::Settings::Helper#settings` now returns `{}` when an extension has no explicit settings
 - `region.default_affinity` now defaults to `any`
+- `[]`, `dig`, and no-arg `load` now share the same project-env-aware load path, and the README now documents the actual `load`/`Loader.default_directories` split
 
 ### Fixed
+- `validate!` now clears stale validation errors before rebuilding state, and nested schema branches now fail when a hash-shaped setting is replaced with a scalar
+- Loader mutation paths now invalidate indifferent-access and digest caches consistently, `load_module_default` no longer overwrites existing scalar settings, and resolver traversal now handles arrays of hashes
 - `Resolver` now treats clustered Vault connectivity from `Legion::Crypt` as available for `vault://` resolution instead of relying only on the top-level `crypt.vault.connected` flag
 - Logger-backed settings code paths now use consistent `log.debug/info/warn/error` behavior instead of mixed direct `Legion::Logging.*` calls
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Legion::Settings Changelog
 
+## [1.3.26] - 2026-04-02
+
+### Changed
+- Added a runtime dependency on `legion-logging >= 1.4.0` and moved `Settings`, `Loader`, `Resolver`, `ProjectEnv`, and `AgentLoader` onto component-aware logging helpers
+- `extensions.default_extension_settings` now defaults to `{}` instead of injecting a synthetic logger config
+- `Legion::Settings::Helper#settings` now returns `{}` when an extension has no explicit settings
+- `region.default_affinity` now defaults to `any`
+
+### Fixed
+- `Resolver` now treats clustered Vault connectivity from `Legion::Crypt` as available for `vault://` resolution instead of relying only on the top-level `crypt.vault.connected` flag
+- Logger-backed settings code paths now use consistent `log.debug/info/warn/error` behavior instead of mixed direct `Legion::Logging.*` calls
+
 ## [1.3.25] - 2026-03-31
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Configuration management module for the [LegionIO](https://github.com/LegionIO/LegionIO) framework. Loads settings from JSON files, directories, and environment variables. Provides a unified `Legion::Settings[:key]` accessor used by all other Legion gems.
 
-**Version**: 1.3.22
+**Version**: 1.3.26
 
 ## Installation
 
@@ -21,20 +21,28 @@ gem 'legion-settings'
 ```ruby
 require 'legion/settings'
 
-Legion::Settings.load(config_dir: './')  # loads all .json files in the directory
+Legion::Settings.load                          # loads defaults, env, DNS bootstrap, and nearest .legionio.env
+Legion::Settings.load(config_dir: './settings') # also loads all .json files in the directory
 
 Legion::Settings[:client][:hostname]
-Legion::Settings[:transport][:connection][:host]
+Legion::Settings.dig(:transport, :connection, :host)
 ```
 
-### Config Paths (checked in order)
+`[]` and `dig` will auto-load settings on first access, and implicit access follows the same overlay/project-env/base precedence as explicit `load`.
 
-1. `/etc/legionio/`
-2. `~/.legionio/settings/`
-3. `~/legionio/`
-4. `./settings/`
+### Config Loading
 
-Each Legion module registers its own defaults via `merge_settings` during startup.
+`Legion::Settings.load` only consumes the paths you pass via `config_file`, `config_dir`, or `config_dirs`.
+
+If a caller wants the canonical Legion search directories, use `Legion::Settings::Loader.default_directories`:
+
+1. `~/.legionio/settings`
+2. `/etc/legionio/settings` on Unix-like systems
+3. `%APPDATA%\\legionio\\settings` on Windows when `APPDATA` is present
+
+`LegionIO` uses those directories during daemon boot. Library consumers can choose to pass any directory set they want.
+
+Each Legion module registers its own defaults via `merge_settings` during startup, and the nearest `.legionio.env` file is merged on top of base settings. Request overlays applied through `with_overlay` take highest precedence.
 
 ### Secret Resolution
 
@@ -76,25 +84,25 @@ Legion::Settings.validate!  # raises ValidationError if any settings are invalid
 
 # In development, warn instead of raising:
 # Set LEGION_DEV=true or Legion::Settings.set_prop(:dev, true)
-# validate! will warn to $stderr (or Legion::Logging) instead of raising
+# validate! will warn through the configured logger instead of raising
 ```
 
 ### Logging Defaults
 
-The `logging` key includes a `transport` sub-section (new in 1.3.22) that controls whether log events are forwarded over the message bus:
+The `logging` key includes a `transport` sub-section that controls whether log events are forwarded over the message bus:
 
 ```json
 {
   "logging": {
     "level": "info",
     "format": "text",
-    "log_file": null,
+    "log_file": "./legionio/logs/legion.log",
     "log_stdout": true,
     "trace": true,
     "async": true,
     "include_pid": false,
     "transport": {
-      "enabled": false,
+      "enabled": true,
       "forward_logs": true,
       "forward_exceptions": true
     }
@@ -102,7 +110,7 @@ The `logging` key includes a `transport` sub-section (new in 1.3.22) that contro
 }
 ```
 
-When `transport.enabled` is `true`, log events and unhandled exceptions are published to the AMQP bus so a central log consumer can aggregate them. Disabled by default to avoid a dependency on `legion-transport` at boot.
+When `transport.enabled` is `true`, log events and unhandled exceptions are published to the AMQP bus so a central log consumer can aggregate them.
 
 ## Requirements
 

--- a/legion-settings.gemspec
+++ b/legion-settings.gemspec
@@ -27,4 +27,5 @@ Gem::Specification.new do |spec|
   }
 
   spec.add_dependency 'legion-json', '>= 1.2.0'
+  spec.add_dependency 'legion-logging', '>= 1.4.0'
 end

--- a/legion-settings.gemspec
+++ b/legion-settings.gemspec
@@ -27,5 +27,5 @@ Gem::Specification.new do |spec|
   }
 
   spec.add_dependency 'legion-json', '>= 1.2.0'
-  spec.add_dependency 'legion-logging', '>= 1.4.0'
+  spec.add_dependency 'legion-logging', '>= 1.5.0'
 end

--- a/lib/legion/settings.rb
+++ b/lib/legion/settings.rb
@@ -18,6 +18,8 @@ module Legion
     class << self
       attr_accessor :loader
 
+      include Legion::Logging::Helper
+
       def load(options = {})
         has_config = options[:config_file] || options[:config_dir] || options[:config_dirs]&.any?
 
@@ -53,7 +55,7 @@ module Legion
 
       def [](key)
         logger.info('Legion::Settings was not loaded, auto-loading now') if @loader.nil?
-        ensure_loader
+        load if @loader.nil?
         overlay_val = Overlay.overlay_for(key)
         base_val = @loader[key]
         if overlay_val.is_a?(Hash) && base_val.is_a?(Hash)
@@ -69,8 +71,16 @@ module Legion
       end
 
       def dig(*keys)
-        ensure_loader
-        @loader.dig(*keys)
+        return nil if keys.empty?
+
+        logger.info('Legion::Settings was not loaded, auto-loading now') if @loader.nil?
+        load if @loader.nil?
+
+        root = self[keys.first]
+        return root if keys.length == 1
+        return nil unless root.respond_to?(:dig)
+
+        root.dig(*keys[1..])
       rescue NoMethodError, TypeError => e
         logger.debug("Legion::Settings#dig keys=#{keys.inspect} failed: #{e.message}")
         nil
@@ -117,7 +127,9 @@ module Legion
       # @return [String, nil] path to the loaded file, or nil if none found
       def load_project_env(start_dir: nil)
         ensure_loader
-        ProjectEnv.load_into(@loader.settings, start_dir: start_dir)
+        path = ProjectEnv.load_into(@loader.settings, start_dir: start_dir)
+        @loader.mark_dirty! if path
+        path
       end
 
       def dev_mode?
@@ -181,19 +193,15 @@ module Legion
       end
 
       def logger
-        @logger = if ::Legion.const_defined?('Logging')
-                    ::Legion::Logging
-                  else
-                    require 'logger'
-                    l = ::Logger.new($stdout)
-                    l.formatter = proc do |severity, datetime, _progname, msg|
-                      "[#{datetime.strftime('%Y-%m-%d %H:%M:%S %z')}] #{severity} #{msg}\n"
-                    end
-                    l
-                  end
+        log
       end
 
       private
+
+      def resolve_logger_settings
+        raw_logging = @loader&.settings&.dig(:logging)
+        raw_logging.is_a?(Hash) ? raw_logging : Legion::Logging::Settings.default
+      end
 
       def deep_merge_for_overlay(base, overlay)
         result = base.dup
@@ -238,6 +246,7 @@ module Legion
       end
 
       def revalidate_all_modules
+        @loader.errors.clear
         schema.registered_modules.each do |mod_name|
           values = @loader[mod_name]
           next unless values.is_a?(Hash)

--- a/lib/legion/settings.rb
+++ b/lib/legion/settings.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require 'legion/json'
+require 'legion/logging'
 require 'legion/settings/version'
 require 'legion/json/parse_error'
 require 'legion/settings/loader'
@@ -51,7 +52,7 @@ module Legion
       end
 
       def [](key)
-        logger.info('Legion::Settings was not loading, auto loading now!') if @loader.nil?
+        logger.info('Legion::Settings was not loaded, auto-loading now') if @loader.nil?
         ensure_loader
         overlay_val = Overlay.overlay_for(key)
         base_val = @loader[key]
@@ -63,7 +64,7 @@ module Legion
           base_val
         end
       rescue NoMethodError, TypeError => e
-        Legion::Logging.debug("Legion::Settings#[] key=#{key} failed: #{e.message}") if defined?(Legion::Logging)
+        logger.debug("Legion::Settings#[] key=#{key} failed: #{e.message}")
         nil
       end
 
@@ -71,7 +72,7 @@ module Legion
         ensure_loader
         @loader.dig(*keys)
       rescue NoMethodError, TypeError => e
-        Legion::Logging.debug("Legion::Settings#dig keys=#{keys.inspect} failed: #{e.message}") if defined?(Legion::Logging)
+        logger.debug("Legion::Settings#dig keys=#{keys.inspect} failed: #{e.message}")
         nil
       end
 
@@ -124,7 +125,7 @@ module Legion
 
         Legion::Settings[:dev] ? true : false
       rescue StandardError => e
-        Legion::Logging.debug("Legion::Settings#dev_mode? failed: #{e.message}") if defined?(Legion::Logging)
+        logger.debug("Legion::Settings#dev_mode? failed: #{e.message}")
         false
       end
 
@@ -133,7 +134,7 @@ module Legion
 
         Legion::Settings[:enterprise_data_privacy] ? true : false
       rescue StandardError => e
-        Legion::Logging.debug("Legion::Settings#enterprise_privacy? failed: #{e.message}") if defined?(Legion::Logging)
+        logger.debug("Legion::Settings#enterprise_privacy? failed: #{e.message}")
         false
       end
 
@@ -212,6 +213,7 @@ module Legion
 
         @loader = Legion::Settings::Loader.new
         @loader.load_env
+        logger.debug('Initialized Legion::Settings loader without config files')
         @loader
       end
 
@@ -224,11 +226,7 @@ module Legion
         label = count == 1 ? 'error' : 'errors'
         message = "Legion::Settings dev mode: #{count} configuration #{label} detected (not raising):\n"
         message += errs.map { |e| "  [#{e[:module]}] #{e[:path]}: #{e[:message]}" }.join("\n")
-        if ::Legion.const_defined?('Logging')
-          ::Legion::Logging.warn(message)
-        else
-          warn(message)
-        end
+        logger.warn(message)
       end
 
       def validate_module_on_merge(mod_name)

--- a/lib/legion/settings/agent_loader.rb
+++ b/lib/legion/settings/agent_loader.rb
@@ -2,10 +2,13 @@
 
 require 'yaml'
 require 'json'
+require 'legion/logging'
 
 module Legion
   module Settings
     module AgentLoader
+      extend Legion::Logging::Helper
+
       EXTENSIONS = %w[.yaml .yml .json].freeze
       GLOB = '*.{yaml,yml,json}'
 
@@ -44,12 +47,17 @@ module Legion
 
         private
 
+        def resolve_logger_settings
+          raw_logging = Legion::Settings.loader&.settings&.dig(:logging) if Legion::Settings.respond_to?(:loader)
+          raw_logging.is_a?(Hash) ? raw_logging : Legion::Logging::Settings.default
+        end
+
         def log_debug(message)
-          Legion::Logging.debug(message) if defined?(Legion::Logging)
+          log.debug(message)
         end
 
         def log_warn(message)
-          defined?(Legion::Logging) ? Legion::Logging.warn(message) : warn(message)
+          log.warn(message)
         end
       end
     end

--- a/lib/legion/settings/dns_bootstrap.rb
+++ b/lib/legion/settings/dns_bootstrap.rb
@@ -5,10 +5,13 @@ require 'json'
 require 'net/http'
 require 'resolv'
 require 'uri'
+require 'legion/logging'
 
 module Legion
   module Settings
     class DnsBootstrap
+      include Legion::Logging::Helper
+
       CACHE_FILENAME = '_dns_bootstrap.json'
       HOSTNAME_PREFIX = 'legion-bootstrap'
       URL_PATH = '/legion/bootstrap.json'
@@ -28,7 +31,7 @@ module Legion
         Resolv.getaddress(@hostname)
         true
       rescue Resolv::ResolvError, Resolv::ResolvTimeout => e
-        log_debug("Legion::Settings::DnsBootstrap#resolve? could not resolve #{@hostname}: #{e.message}")
+        log.debug("Legion::Settings::DnsBootstrap#resolve? could not resolve #{@hostname}: #{e.message}")
         false
       end
 
@@ -45,7 +48,7 @@ module Legion
 
         ::JSON.parse(response.body, symbolize_names: true)
       rescue StandardError => e
-        log_warn("DNS bootstrap fetch failed for #{@url}: #{e.message}")
+        log.warn("DNS bootstrap fetch failed for #{@url}: #{e.message}")
         nil
       end
 
@@ -67,11 +70,11 @@ module Legion
         return nil unless File.exist?(@cache_path)
 
         raw = ::JSON.parse(File.read(@cache_path), symbolize_names: true)
-        log_debug("DNS bootstrap cache hit: #{@cache_path}")
+        log.debug("DNS bootstrap cache hit: #{@cache_path}")
         raw.delete(:_dns_bootstrap_meta)
         raw
       rescue ::JSON::ParserError
-        log_warn("DNS bootstrap cache corrupt, deleting: #{@cache_path}")
+        log.warn("DNS bootstrap cache corrupt, deleting: #{@cache_path}")
         FileUtils.rm_f(@cache_path)
         nil
       end
@@ -82,12 +85,9 @@ module Legion
 
       private
 
-      def log_debug(message)
-        Legion::Logging.debug(message) if defined?(Legion::Logging)
-      end
-
-      def log_warn(message)
-        defined?(Legion::Logging) ? Legion::Logging.warn(message) : warn(message)
+      def resolve_logger_settings
+        raw_logging = Legion::Settings.loader&.settings&.dig(:logging) if Legion::Settings.respond_to?(:loader)
+        raw_logging.is_a?(Hash) ? raw_logging : Legion::Logging::Settings.default
       end
     end
   end

--- a/lib/legion/settings/helper.rb
+++ b/lib/legion/settings/helper.rb
@@ -8,7 +8,7 @@ module Legion
         if Legion::Settings[:extensions]&.key?(ext_key)
           Legion::Settings[:extensions][ext_key]
         else
-          { logger: { level: 'info', extended: false, internal: false } }
+          {}
         end
       end
 

--- a/lib/legion/settings/loader.rb
+++ b/lib/legion/settings/loader.rb
@@ -2,6 +2,7 @@
 
 require 'resolv'
 require 'socket'
+require 'legion/logging'
 require 'legion/settings/os'
 require_relative 'dns_bootstrap'
 
@@ -9,6 +10,7 @@ module Legion
   module Settings
     class Loader
       include Legion::Settings::OS
+      include Legion::Logging::Helper
 
       class Error < RuntimeError; end
       attr_reader :warnings, :errors, :loaded_files, :settings
@@ -36,6 +38,7 @@ module Legion
         @settings = default_settings
         @indifferent_access = false
         @loaded_files = []
+        log.debug('Initialized Legion::Settings::Loader with default settings')
       end
 
       def dns_defaults
@@ -138,16 +141,14 @@ module Legion
           reload:                     false,
           reloading:                  false,
           auto_install_missing_lex:   true,
-          default_extension_settings: {
-            logger: { level: 'info', trace: false, extended: false }
-          },
+          default_extension_settings: {},
           logging:                    logging_defaults,
           absorbers:                  absorbers_defaults,
           transport:                  { connected: false },
           data:                       { connected: false },
           role:                       { profile: nil, extensions: [] },
           region:                     { current: nil, primary: nil, failover: nil, peers: [],
-                                        default_affinity: 'prefer_local', data_residency: {} },
+                                        default_affinity: 'any', data_residency: {} },
           process:                    { role: 'full' },
           dns:                        dns_defaults
         }
@@ -243,6 +244,7 @@ module Legion
             @settings = merged
             # @indifferent_access = false
             @loaded_files << file
+            log.debug("Loaded settings file #{file}")
           rescue Legion::JSON::ParseError => e
             log_error("config file must be valid json: #{file}")
             log_error("  parse error: #{e.message}")
@@ -289,6 +291,11 @@ module Legion
       end
 
       private
+
+      def resolve_logger_settings
+        raw_logging = instance_variable_defined?(:@settings) ? @settings&.[](:logging) : nil
+        raw_logging.is_a?(Hash) ? raw_logging : Legion::Logging::Settings.default
+      end
 
       def load_dns_from_cache(bootstrap)
         config = bootstrap.read_cache
@@ -422,7 +429,7 @@ module Legion
       def system_hostname
         Socket.gethostname
       rescue StandardError => e
-        Legion::Logging.debug("Legion::Settings::Loader#system_hostname failed: #{e.message}") if defined?(Legion::Logging)
+        log_debug("Legion::Settings::Loader#system_hostname failed: #{e.message}")
         'unknown'
       end
 
@@ -431,7 +438,7 @@ module Legion
         preferred = addresses.find { |a| rfc1918?(a.ip_address) }
         (preferred || addresses.first)&.ip_address || 'unknown'
       rescue StandardError => e
-        Legion::Logging.debug("Legion::Settings::Loader#system_address failed: #{e.message}") if defined?(Legion::Logging)
+        log_debug("Legion::Settings::Loader#system_address failed: #{e.message}")
         'unknown'
       end
 
@@ -442,19 +449,19 @@ module Legion
       end
 
       def log_info(message)
-        defined?(Legion::Logging) ? Legion::Logging.info(message) : $stdout.puts(message)
+        log.info(message)
       end
 
       def log_debug(message)
-        Legion::Logging.debug(message) if defined?(Legion::Logging)
+        log.debug(message)
       end
 
       def log_warn(message)
-        defined?(Legion::Logging) ? Legion::Logging.warn(message) : warn(message)
+        log.warn(message)
       end
 
       def log_error(message)
-        defined?(Legion::Logging) ? Legion::Logging.error(message) : warn(message)
+        log.error(message)
       end
 
       def warning(message, data = {})

--- a/lib/legion/settings/loader.rb
+++ b/lib/legion/settings/loader.rb
@@ -2,6 +2,8 @@
 
 require 'resolv'
 require 'socket'
+require 'digest'
+require 'tmpdir'
 require 'legion/logging'
 require 'legion/settings/os'
 require_relative 'dns_bootstrap'
@@ -172,7 +174,7 @@ module Legion
 
       def []=(key, value)
         @settings[key] = value
-        @indifferent_access = false
+        mark_dirty!
       end
 
       def hexdigest
@@ -221,16 +223,14 @@ module Legion
         mod_name = config.keys.first
         log_debug("Loading module settings: #{mod_name}")
         @settings = deep_merge(config, @settings)
-        @indifferent_access = false
+        mark_dirty!
       end
 
       def load_module_default(config)
         mod_name = config.keys.first
         log_debug("Loading module defaults: #{mod_name}")
-        merged = deep_merge(@settings, config)
-        deep_diff(@settings, merged) unless @loaded_files.empty?
-        @settings = merged
-        @indifferent_access = false
+        @settings = deep_merge(config, @settings)
+        mark_dirty!
       end
 
       def load_file(file)
@@ -239,10 +239,8 @@ module Legion
           begin
             contents = read_config_file(file)
             config = contents.empty? ? {} : Legion::JSON.load(contents)
-            merged = deep_merge(@settings, config)
-            deep_diff(@settings, merged) unless @loaded_files.empty?
-            @settings = merged
-            # @indifferent_access = false
+            @settings = deep_merge(@settings, config)
+            mark_dirty!
             @loaded_files << file
             log.debug("Loaded settings file #{file}")
           rescue Legion::JSON::ParseError => e
@@ -257,7 +255,7 @@ module Legion
       def load_directory(directory)
         path = directory.gsub(/\\(?=\S)/, '/')
         if File.readable?(path) && File.executable?(path)
-          files = Dir.glob(File.join(path, '**{,/*/**}/*.json')).uniq
+          files = Dir.glob(File.join(path, '**', '*.json'))
           files.each { |file| load_file(file) }
           log_info("Settings: loaded directory #{path} (#{files.size} files)")
         else
@@ -270,7 +268,7 @@ module Legion
         if @settings[:client][:subscriptions].is_a?(Array)
           @settings[:client][:subscriptions] << "client:#{@settings[:client][:name]}"
           @settings[:client][:subscriptions].uniq!
-          @indifferent_access = false
+          mark_dirty!
         else
           log_warn('unable to apply legion client overrides, reason: client subscriptions is not an array')
         end
@@ -318,7 +316,7 @@ module Legion
           hostname:   bootstrap.hostname,
           url:        bootstrap.url
         }
-        @indifferent_access = false
+        mark_dirty!
       end
 
       def start_dns_background_refresh(bootstrap)
@@ -364,14 +362,14 @@ module Legion
         @settings[:api] ||= {}
         @settings[:api][:port] = ENV['LEGION_API_PORT'].to_i
         log_warn("using api port environment variable, api: #{@settings[:api]}")
-        @indifferent_access = false
+        mark_dirty!
       end
 
       def load_privacy_env
         return unless ENV['LEGION_ENTERPRISE_PRIVACY'] == 'true'
 
         @settings[:enterprise_data_privacy] = true
-        @indifferent_access = false
+        mark_dirty!
       end
 
       def read_config_file(file)
@@ -401,19 +399,6 @@ module Legion
         merged
       end
 
-      def deep_diff(hash_one, hash_two)
-        keys = hash_one.keys.concat(hash_two.keys).uniq
-        keys.each_with_object({}) do |key, diff|
-          next if hash_one[key] == hash_two[key]
-
-          diff[key] = if hash_one[key].is_a?(Hash) && hash_two[key].is_a?(Hash)
-                        deep_diff(hash_one[key], hash_two[key])
-                      else
-                        [hash_one[key], hash_two[key]]
-                      end
-        end
-      end
-
       def create_loaded_tempfile!
         dir = ENV['LEGION_LOADED_TEMPFILE_DIR'] || Dir.tmpdir
         file_name = "legion_#{legion_service_name}_loaded_files"
@@ -421,6 +406,15 @@ module Legion
         File.write(path, @loaded_files.join(':'))
         path
       end
+
+      public
+
+      def mark_dirty!
+        @indifferent_access = false
+        @hexdigest = nil
+      end
+
+      private
 
       def legion_service_name
         File.basename($PROGRAM_NAME).split('-').last

--- a/lib/legion/settings/project_env.rb
+++ b/lib/legion/settings/project_env.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require 'legion/logging'
+
 module Legion
   module Settings
     # Per-project `.legionio.env` config file loader.
@@ -19,6 +21,8 @@ module Legion
     # Resolution order (lowest → highest priority):
     #   global settings < .legionio.env < request overlay (#9)
     module ProjectEnv
+      extend Legion::Logging::Helper
+
       ENV_FILENAME = '.legionio.env'
 
       class << self
@@ -87,6 +91,11 @@ module Legion
 
         private
 
+        def resolve_logger_settings
+          raw_logging = Legion::Settings.loader&.settings&.dig(:logging) if Legion::Settings.respond_to?(:loader)
+          raw_logging.is_a?(Hash) ? raw_logging : Legion::Logging::Settings.default
+        end
+
         def set_nested(hash, keys, value)
           *parents, leaf = keys
           target = parents.reduce(hash) do |h, k|
@@ -108,11 +117,11 @@ module Legion
         end
 
         def log_debug(message)
-          defined?(Legion::Logging) ? Legion::Logging.debug(message) : nil
+          log.debug(message)
         end
 
         def log_warn(message)
-          defined?(Legion::Logging) ? Legion::Logging.warn(message) : warn(message)
+          log.warn(message)
         end
       end
     end

--- a/lib/legion/settings/resolver.rb
+++ b/lib/legion/settings/resolver.rb
@@ -85,15 +85,11 @@ module Legion
       end
 
       def count_vault_refs(hash)
-        return 0 unless hash.is_a?(Hash)
-
-        hash.sum do |_key, value|
-          case value
-          when String then value.match?(VAULT_PATTERN) ? 1 : 0
-          when Array  then value.count { |v| v.is_a?(String) && v.match?(VAULT_PATTERN) }
-          when Hash   then count_vault_refs(value)
-          else 0
-          end
+        case hash
+        when String then hash.match?(VAULT_PATTERN) ? 1 : 0
+        when Array  then hash.sum { |value| count_vault_refs(value) }
+        when Hash   then hash.sum { |_key, value| count_vault_refs(value) }
+        else 0
         end
       end
 
@@ -109,38 +105,59 @@ module Legion
         false
       end
 
-      def walk(hash, path:, &block)
-        hash.each do |key, value|
-          current_path = path.empty? ? key.to_s : "#{path}.#{key}"
-
-          case value
-          when Hash
-            walk(value, path: current_path, &block)
-          when String
-            next unless value.match?(URI_PATTERN)
-
-            resolved = resolve_single(value)
-            if resolved.nil?
-              log_warn("Settings resolver: could not resolve #{current_path} (#{value})")
-              block&.call(:unresolved)
-            else
-              hash[key] = resolved
-              register_lease_ref(value, current_path) if value.match?(LEASE_PATTERN)
-              block&.call(:resolved)
-            end
-          when Array
-            next unless resolvable_chain?(value)
-
-            resolved = resolve_chain(value)
-            if resolved.nil?
-              log_warn("Settings resolver: fallback chain exhausted for #{current_path}")
-              block&.call(:unresolved)
-            else
-              hash[key] = resolved
-              register_lease_refs_from_chain(value, current_path)
-              block&.call(:resolved)
-            end
+      def walk(hash, path:, &)
+        case hash
+        when Hash
+          hash.each do |key, value|
+            current_path = path.empty? ? key.to_s : "#{path}.#{key}"
+            walk_value(hash, key, value, current_path, &)
           end
+        when Array
+          hash.each_with_index do |value, index|
+            current_path = "#{path}[#{index}]"
+            walk_value(hash, index, value, current_path, &)
+          end
+        end
+      end
+
+      def walk_value(container, key, value, current_path, &)
+        case value
+        when Hash
+          walk(value, path: current_path, &)
+        when String
+          handle_string_value(container, key, value, current_path) { |status| yield(status) if block_given? }
+        when Array
+          handle_array_value(container, key, value, current_path) { |status| yield(status) if block_given? }
+        end
+      end
+
+      def handle_string_value(container, key, value, current_path)
+        return unless value.match?(URI_PATTERN)
+
+        resolved = resolve_single(value)
+        if resolved.nil?
+          log_warn("Settings resolver: could not resolve #{current_path} (#{value})")
+          yield(:unresolved) if block_given?
+        else
+          container[key] = resolved
+          register_lease_ref(value, current_path) if value.match?(LEASE_PATTERN)
+          yield(:resolved) if block_given?
+        end
+      end
+
+      def handle_array_value(container, key, value, current_path, &)
+        if resolvable_chain?(value) && value.all? { |entry| !entry.is_a?(Hash) && !entry.is_a?(Array) }
+          resolved = resolve_chain(value)
+          if resolved.nil?
+            log_warn("Settings resolver: fallback chain exhausted for #{current_path}")
+            yield(:unresolved) if block_given?
+          else
+            container[key] = resolved
+            register_lease_refs_from_chain(value, current_path)
+            yield(:resolved) if block_given?
+          end
+        else
+          walk(value, path: current_path, &)
         end
       end
 
@@ -213,15 +230,11 @@ module Legion
       end
 
       def count_lease_refs(hash)
-        return 0 unless hash.is_a?(Hash)
-
-        hash.sum do |_key, value|
-          case value
-          when String then value.match?(LEASE_PATTERN) ? 1 : 0
-          when Array  then value.count { |v| v.is_a?(String) && v.match?(LEASE_PATTERN) }
-          when Hash   then count_lease_refs(value)
-          else 0
-          end
+        case hash
+        when String then hash.match?(LEASE_PATTERN) ? 1 : 0
+        when Array  then hash.sum { |value| count_lease_refs(value) }
+        when Hash   then hash.sum { |_key, value| count_lease_refs(value) }
+        else 0
         end
       end
 

--- a/lib/legion/settings/resolver.rb
+++ b/lib/legion/settings/resolver.rb
@@ -1,8 +1,12 @@
 # frozen_string_literal: true
 
+require 'legion/logging'
+
 module Legion
   module Settings
     module Resolver
+      extend Legion::Logging::Helper
+
       VAULT_PATTERN  = %r{\Avault://(.+?)#(.+)\z}
       ENV_PATTERN    = %r{\Aenv://(.+)\z}
       LEASE_PATTERN  = %r{\Alease://(.+?)#(.+)\z}
@@ -96,8 +100,10 @@ module Legion
       def vault_connected?
         return false unless defined?(Legion::Crypt)
         return false unless defined?(Legion::Settings)
+        return Legion::Crypt.vault_connected? if Legion::Crypt.respond_to?(:vault_connected?)
 
-        Legion::Settings[:crypt][:vault][:connected] == true
+        Legion::Settings[:crypt][:vault][:connected] == true ||
+          (Legion::Crypt.respond_to?(:connected_clusters) && Legion::Crypt.connected_clusters.any?)
       rescue StandardError => e
         log_debug("Legion::Settings::Resolver#vault_connected? failed: #{e.message}")
         false
@@ -219,28 +225,21 @@ module Legion
         end
       end
 
+      def resolve_logger_settings
+        raw_logging = Legion::Settings.loader&.settings&.dig(:logging) if Legion::Settings.respond_to?(:loader)
+        raw_logging.is_a?(Hash) ? raw_logging : Legion::Logging::Settings.default
+      end
+
       def log_info(message)
-        if defined?(Legion::Logging)
-          Legion::Logging.info(message)
-        else
-          $stdout.puts(message)
-        end
+        log.info(message)
       end
 
       def log_warn(message)
-        if defined?(Legion::Logging)
-          Legion::Logging.warn(message)
-        else
-          warn(message)
-        end
+        log.warn(message)
       end
 
       def log_debug(message)
-        if defined?(Legion::Logging)
-          Legion::Logging.debug(message)
-        else
-          $stdout.puts(message)
-        end
+        log.debug(message)
       end
     end
   end

--- a/lib/legion/settings/schema.rb
+++ b/lib/legion/settings/schema.rb
@@ -113,7 +113,14 @@ module Legion
           if constraint.is_a?(Hash) && constraint.key?(:type)
             validate_leaf(constraint, value, mod_name, current_path, errors)
           elsif constraint.is_a?(Hash)
-            validate_node(constraint, value, mod_name, current_path, errors) if value.is_a?(Hash)
+            next if value.nil?
+
+            if value.is_a?(Hash)
+              validate_node(constraint, value, mod_name, current_path, errors)
+            else
+              errors << { module: mod_name, path: current_path,
+                          message: "expected Hash, got #{value.class} (#{value.inspect})" }
+            end
           end
         end
       end

--- a/lib/legion/settings/version.rb
+++ b/lib/legion/settings/version.rb
@@ -2,6 +2,6 @@
 
 module Legion
   module Settings
-    VERSION = '1.3.25'
+    VERSION = '1.3.26'
   end
 end

--- a/spec/legion/loader_spec.rb
+++ b/spec/legion/loader_spec.rb
@@ -388,6 +388,13 @@ RSpec.describe Legion::Settings::Loader do
       expect(loader[:new_module]).to be_a(Hash)
       expect(loader[:new_module][:key]).to eq('value')
     end
+
+    it 'does not overwrite existing scalar values' do
+      loader[:custom_module] = { mode: 'runtime' }
+      loader.load_module_default({ custom_module: { mode: 'default', enabled: true } })
+      expect(loader[:custom_module][:mode]).to eq('runtime')
+      expect(loader[:custom_module][:enabled]).to eq(true)
+    end
   end
 
   describe '#set_env!' do
@@ -556,6 +563,13 @@ RSpec.describe Legion::Settings::Loader do
       loader.to_hash
       loader.load_module_default({ extra: { key: 'default_value' } })
       expect(loader['extra']).to eq({ key: 'default_value' })
+    end
+
+    it 'load_file resets @indifferent_access so string keys work after to_hash' do
+      loader.to_hash
+      loader.load_file(config_file)
+      expect(loader['api']).to eq(loader[:api])
+      expect(loader['custom_key']).to eq('test_value')
     end
   end
 end

--- a/spec/legion/loader_spec.rb
+++ b/spec/legion/loader_spec.rb
@@ -270,8 +270,10 @@ RSpec.describe Legion::Settings::Loader do
 
     it 'logs the filename when JSON is invalid' do
       invalid_file = File.join(assets_dir, 'invalid.json')
-      expect(Legion::Logging).to receive(:error).with(a_string_including(invalid_file))
-      expect(Legion::Logging).to receive(:error).with(a_string_matching(/parse error/))
+      logger = instance_double('Logger', error: nil, debug: nil)
+      allow(loader).to receive(:log).and_return(logger)
+      expect(logger).to receive(:error).with(a_string_including(invalid_file))
+      expect(logger).to receive(:error).with(a_string_matching(/parse error/))
       loader.load_file(invalid_file)
     end
 

--- a/spec/legion/settings/dev_mode_spec.rb
+++ b/spec/legion/settings/dev_mode_spec.rb
@@ -79,10 +79,12 @@ RSpec.describe 'Legion::Settings dev mode' do
       expect { Legion::Settings.validate! }.not_to raise_error
     end
 
-    it 'writes a warning to $stderr when Legion::Logging is unavailable' do
-      allow(Legion).to receive(:const_defined?).with('Logging').and_return(false)
+    it 'logs a warning through the configured logger' do
+      logger = instance_double('Logger', warn: nil)
+      allow(Legion::Settings).to receive(:logger).and_return(logger)
       inject_type_error
-      expect { Legion::Settings.validate! }.to output(/dev mode/).to_stderr
+      Legion::Settings.validate!
+      expect(logger).to have_received(:warn).with(include('dev mode'))
     end
 
     it 'does not raise when settings are valid' do
@@ -102,18 +104,22 @@ RSpec.describe 'Legion::Settings dev mode' do
   describe 'warning message content' do
     before do
       ENV['LEGION_DEV'] = 'true'
-      allow(Legion).to receive(:const_defined?).with('Logging').and_return(false)
     end
 
     it 'includes error count and module path in the warning' do
+      logger = instance_double('Logger', warn: nil)
+      allow(Legion::Settings).to receive(:logger).and_return(logger)
       inject_type_error
-      expect { Legion::Settings.validate! }.to output(/\[devmod\]/).to_stderr
+      Legion::Settings.validate!
+      expect(logger).to have_received(:warn).with(include('[devmod]'))
     end
 
     it 'uses singular "error" for a single error' do
+      logger = instance_double('Logger', warn: nil)
+      allow(Legion::Settings).to receive(:logger).and_return(logger)
       inject_type_error
-      # Ensure only one error is present (reset and re-inject a single type error)
-      expect { Legion::Settings.validate! }.to output(/configuration error/).to_stderr
+      Legion::Settings.validate!
+      expect(logger).to have_received(:warn).with(include('configuration error'))
     end
   end
 end

--- a/spec/legion/settings/helper_spec.rb
+++ b/spec/legion/settings/helper_spec.rb
@@ -52,9 +52,9 @@ RSpec.describe Legion::Settings::Helper do
     end
 
     context 'when no extension settings exist' do
-      it 'returns defaults' do
+      it 'returns an empty hash' do
         obj = with_lex_filename.new
-        expect(obj.settings).to eq({ logger: { level: 'info', extended: false, internal: false } })
+        expect(obj.settings).to eq({})
       end
     end
   end

--- a/spec/legion/settings/project_env_spec.rb
+++ b/spec/legion/settings/project_env_spec.rb
@@ -189,6 +189,21 @@ RSpec.describe Legion::Settings do
       described_class.load_project_env(start_dir: tmpdir)
       expect(described_class[:cache][:driver]).to eq('redis')
     end
+
+    it 'invalidates the loader digest when project env changes settings' do
+      old_bootstrap = ENV.fetch('LEGION_DNS_BOOTSTRAP', nil)
+      ENV['LEGION_DNS_BOOTSTRAP'] = 'false'
+      described_class.load
+      before_digest = described_class.get.hexdigest
+
+      env_file = File.join(tmpdir, '.legionio.env')
+      File.write(env_file, "cache.driver=redis\n")
+      described_class.load_project_env(start_dir: tmpdir)
+
+      expect(described_class.get.hexdigest).not_to eq(before_digest)
+    ensure
+      ENV['LEGION_DNS_BOOTSTRAP'] = old_bootstrap
+    end
   end
 
   describe 'resolution order: overlay > project env > global' do

--- a/spec/legion/settings/region_spec.rb
+++ b/spec/legion/settings/region_spec.rb
@@ -26,8 +26,8 @@ RSpec.describe 'Region settings' do
       expect(loader.settings[:region][:peers]).to eq([])
     end
 
-    it 'defaults default_affinity to prefer_local' do
-      expect(loader.settings[:region][:default_affinity]).to eq('prefer_local')
+    it 'defaults default_affinity to any' do
+      expect(loader.settings[:region][:default_affinity]).to eq('any')
     end
 
     it 'defaults data_residency to empty hash' do
@@ -63,7 +63,7 @@ RSpec.describe 'Region settings' do
 
     it 'preserves default_affinity when merging partial config' do
       Legion::Settings.merge_settings(:region, { current: 'us-west-2' })
-      expect(Legion::Settings.dig(:region, :default_affinity)).to eq('prefer_local')
+      expect(Legion::Settings.dig(:region, :default_affinity)).to eq('any')
     end
 
     it 'allows overriding default_affinity via direct mutation' do

--- a/spec/legion/settings/resolver_spec.rb
+++ b/spec/legion/settings/resolver_spec.rb
@@ -313,6 +313,7 @@ RSpec.describe Legion::Settings::Resolver do
 
     context 'when vault is connected' do
       before do
+        allow(Legion::Settings).to receive(:[]).and_call_original
         allow(Legion::Settings).to receive(:[]).with(:crypt).and_return({ vault: { connected: true } })
       end
 
@@ -346,8 +347,23 @@ RSpec.describe Legion::Settings::Resolver do
       end
     end
 
+    context 'when a clustered Vault connection is available through Legion::Crypt' do
+      before do
+        allow(Legion::Settings).to receive(:[]).and_call_original
+        allow(Legion::Settings).to receive(:[]).with(:crypt).and_return({ vault: { connected: false } })
+        allow(Legion::Crypt).to receive(:vault_connected?).and_return(true)
+      end
+
+      it 'resolves vault:// values using the connected cluster path' do
+        settings = { secret: 'vault://secret/data/transport#username' }
+        described_class.resolve_secrets!(settings)
+        expect(settings[:secret]).to eq('vault_user')
+      end
+    end
+
     context 'when vault is not connected' do
       before do
+        allow(Legion::Settings).to receive(:[]).and_call_original
         allow(Legion::Settings).to receive(:[]).with(:crypt).and_return({ vault: { connected: false } })
       end
 

--- a/spec/legion/settings/resolver_spec.rb
+++ b/spec/legion/settings/resolver_spec.rb
@@ -133,6 +133,19 @@ RSpec.describe Legion::Settings::Resolver do
         described_class.resolve_secrets!(settings)
         expect(settings[:api_key]).to eq('top_level_val')
       end
+
+      it 'resolves env:// strings inside arrays of hashes' do
+        ENV['RESOLVER_NESTED_VAR'] = 'array_hash_secret'
+        settings = {
+          clients: [
+            { password: 'env://RESOLVER_NESTED_VAR' },
+            { nested: { token: 'env://RESOLVER_NESTED_VAR' } }
+          ]
+        }
+        described_class.resolve_secrets!(settings)
+        expect(settings[:clients][0][:password]).to eq('array_hash_secret')
+        expect(settings[:clients][1][:nested][:token]).to eq('array_hash_secret')
+      end
     end
 
     context 'with fallback chain arrays in settings' do
@@ -251,6 +264,16 @@ RSpec.describe Legion::Settings::Resolver do
     it 'counts vault:// references recursively in nested hashes' do
       settings = { db: { pass: 'vault://secret/db#password', host: 'localhost' } }
       expect(described_class.count_vault_refs(settings)).to eq(1)
+    end
+
+    it 'counts vault:// references inside arrays of hashes' do
+      settings = {
+        clients: [
+          { password: 'vault://secret/db#password' },
+          { nested: { token: 'vault://secret/app#token' } }
+        ]
+      }
+      expect(described_class.count_vault_refs(settings)).to eq(2)
     end
   end
 
@@ -535,6 +558,16 @@ RSpec.describe Legion::Settings::Resolver do
     it 'counts recursively in nested hashes' do
       settings = { db: { pass: 'lease://postgres#password', host: 'localhost' } }
       expect(described_class.count_lease_refs(settings)).to eq(1)
+    end
+
+    it 'counts lease:// references inside arrays of hashes' do
+      settings = {
+        clients: [
+          { password: 'lease://postgres#password' },
+          { nested: { token: 'lease://rabbitmq#username' } }
+        ]
+      }
+      expect(described_class.count_lease_refs(settings)).to eq(2)
     end
   end
 end

--- a/spec/legion/settings/schema_spec.rb
+++ b/spec/legion/settings/schema_spec.rb
@@ -127,6 +127,14 @@ RSpec.describe Legion::Settings::Schema do
       errors = schema.validate_module(:transport, { connection: { host: 42, port: 'bad' } })
       expect(errors.length).to eq(2)
     end
+
+    it 'fails when a nested hash-shaped branch is replaced with a scalar' do
+      schema.register(:transport, { connection: { host: '127.0.0.1', port: 5672 } })
+      errors = schema.validate_module(:transport, { connection: 'oops' })
+      expect(errors.length).to eq(1)
+      expect(errors.first[:path]).to eq('connection')
+      expect(errors.first[:message]).to include('expected Hash')
+    end
   end
 
   describe '#detect_unknown_keys' do

--- a/spec/legion/settings_module_spec.rb
+++ b/spec/legion/settings_module_spec.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 require 'spec_helper'
+require 'fileutils'
+require 'tmpdir'
 
 RSpec.describe Legion::Settings do
   before do
@@ -30,6 +32,23 @@ RSpec.describe Legion::Settings do
       described_class.load(config_dirs: [config_dir])
       expect(described_class[:cache][:namespace]).to eq('test_ns')
     end
+
+    it 'loads .legionio.env during no-arg load' do
+      dir = Dir.mktmpdir('legion_settings_load_test')
+      old_dir = Dir.pwd
+      old_bootstrap = ENV.fetch('LEGION_DNS_BOOTSTRAP', nil)
+      ENV['LEGION_DNS_BOOTSTRAP'] = 'false'
+      File.write(File.join(dir, '.legionio.env'), "project_env_key=project_value\n")
+
+      Dir.chdir(dir) do
+        described_class.load
+        expect(described_class[:project_env_key]).to eq('project_value')
+      end
+    ensure
+      ENV['LEGION_DNS_BOOTSTRAP'] = old_bootstrap
+      Dir.chdir(old_dir)
+      FileUtils.rm_rf(dir)
+    end
   end
 
   describe '.[]' do
@@ -43,6 +62,48 @@ RSpec.describe Legion::Settings do
 
     it 'returns expected default values' do
       expect(described_class[:cache][:driver]).to eq('dalli')
+    end
+
+    it 'auto-loads .legionio.env when accessed implicitly' do
+      dir = Dir.mktmpdir('legion_settings_implicit_access_test')
+      old_dir = Dir.pwd
+      old_bootstrap = ENV.fetch('LEGION_DNS_BOOTSTRAP', nil)
+      ENV['LEGION_DNS_BOOTSTRAP'] = 'false'
+      File.write(File.join(dir, '.legionio.env'), "project_env_key=implicit_value\n")
+
+      Dir.chdir(dir) do
+        expect(described_class[:project_env_key]).to eq('implicit_value')
+      end
+    ensure
+      ENV['LEGION_DNS_BOOTSTRAP'] = old_bootstrap
+      Dir.chdir(old_dir)
+      FileUtils.rm_rf(dir)
+    end
+  end
+
+  describe '.dig' do
+    it 'applies overlay precedence consistently with []' do
+      described_class.merge_settings('m', { a: 1, b: { c: 2 } })
+
+      described_class.with_overlay(m: { b: { c: 9 } }) do
+        expect(described_class.dig(:m, :b, :c)).to eq(9)
+      end
+    end
+
+    it 'auto-loads .legionio.env when accessed implicitly' do
+      dir = Dir.mktmpdir('legion_settings_implicit_dig_test')
+      old_dir = Dir.pwd
+      old_bootstrap = ENV.fetch('LEGION_DNS_BOOTSTRAP', nil)
+      ENV['LEGION_DNS_BOOTSTRAP'] = 'false'
+      File.write(File.join(dir, '.legionio.env'), "project_env.key=dig_value\n")
+
+      Dir.chdir(dir) do
+        expect(described_class.dig(:project_env, :key)).to eq('dig_value')
+      end
+    ensure
+      ENV['LEGION_DNS_BOOTSTRAP'] = old_bootstrap
+      Dir.chdir(old_dir)
+      FileUtils.rm_rf(dir)
     end
   end
 
@@ -107,6 +168,16 @@ RSpec.describe Legion::Settings do
       described_class.merge_settings('typed', { port: 8080 })
       described_class.loader.settings[:typed][:port] = 'not_a_number'
       expect { described_class.validate! }.to raise_error(Legion::Settings::ValidationError)
+    end
+
+    it 'rebuilds validation errors from scratch on subsequent runs' do
+      described_class.merge_settings('typed', { port: 8080 })
+      described_class.loader.settings[:typed][:port] = 'not_a_number'
+      expect { described_class.validate! }.to raise_error(Legion::Settings::ValidationError)
+
+      described_class.loader.settings[:typed][:port] = 8080
+      expect { described_class.validate! }.not_to raise_error
+      expect(described_class.errors).to be_empty
     end
   end
 


### PR DESCRIPTION
## What

Finish the remaining `legion-settings` issue work for the 1.3.26 release.

## Why

The release branch already had the Vault connectivity and logging baseline fixes, but the open issue set still had gaps around validation reset, nested schema shape checks, implicit vs explicit load behavior, resolver mutation correctness, and README drift.

## Issue Coverage

Closes #12
Closes #13
Closes #14
Closes #15
Closes #16

## Included

- move the remaining settings paths onto `Legion::Logging::Helper`-backed logging, including DNS bootstrap
- make `validate!` rebuild errors from scratch and enforce nested hash-shaped schema branches
- make `[]`, `dig`, and no-arg `load` share the same project-env-aware access path
- invalidate loader digest / indifferent-access caches on mutation paths and keep `load_module_default` from overwriting existing scalars
- recurse resolver traversal and reference counting through arrays of hashes
- align README with actual `load` behavior and logging defaults
- add public-behavior coverage for entrypoints, overlays, mutation paths, and resolver traversal

## Checklist

- [x] Tests pass (`bundle exec rspec`)
- [x] RuboCop passes (`bundle exec rubocop`)
- [x] CHANGELOG.md updated (if user-facing change)
- [x] No new security concerns introduced
